### PR TITLE
Fix: webvtt cues with identifiers

### DIFF
--- a/src/webvtt/data.rs
+++ b/src/webvtt/data.rs
@@ -170,6 +170,7 @@ impl Display for WebVttSubtitle {
         if !self.cues.is_empty() {
             writeln!(f)?;
             for line in &self.cues {
+                writeln!(f)?;
                 writeln!(f, "{line}")?;
             }
         }

--- a/src/webvtt/parse.rs
+++ b/src/webvtt/parse.rs
@@ -74,7 +74,7 @@ fn parse_cue(input: &str) -> IResult<&str, WebVttBlock> {
         tuple((
             alt((
                 pair(opt(parse_cue_identifier), parse_cue_timing),
-                pair(opt(space0), parse_cue_timing),
+                pair(opt(space1), parse_cue_timing),
             )),
             take_until_end_of_block,
         )),

--- a/tests/webvtt_formatting.rs
+++ b/tests/webvtt_formatting.rs
@@ -21,7 +21,7 @@ fn strip_vtt_format() {
 }
 
 #[test]
-fn output() {
+fn basic_output() {
     let vtt = WebVttSubtitle::from_str(
         "WEBVTT
     
@@ -52,6 +52,44 @@ anything
 
 00:00:10.100 --> 00:00:18.999
 everything
+"
+    );
+}
+
+#[test]
+fn identifiers() {
+    let vtt = WebVttSubtitle::from_str(
+        "WEBVTT
+
+1
+00:00:00.650 --> 00:00:01.200
+foo
+
+2
+00:00:04.000 --> 00:00:06.000
+bar
+
+3
+00:00:10.100 --> 00:00:18.999
+baz
+",
+    );
+
+    assert_eq!(
+        vtt.unwrap().to_string(),
+        "WEBVTT
+
+1
+00:00:00.650 --> 00:00:01.200
+foo
+
+2
+00:00:04.000 --> 00:00:06.000
+bar
+
+3
+00:00:10.100 --> 00:00:18.999
+baz
 "
     );
 }


### PR DESCRIPTION
This PR fixes the spacing between WebVTT cues when cues have identifiers. Currently if cues have an identifier that is *not* `None` or `Some("".to_string())`, the WebVTT file will be `Display`ed with no spacing between cues, which is against the spec and stops e.g. the current versions of FFmpeg and QuickTime from using the file.

---

`input.vtt`
```
WEBVTT

1
00:00:00.650 --> 00:00:01.200
foo

2
00:00:04.000 --> 00:00:06.000
bar

3
00:00:10.100 --> 00:00:18.999
baz
```

```rust
let vtt = TimedSubtitleFile::new("input.vtt")
  .map(WebVttSubtitle::from)?
  .export(file.with_extension("output.vtt"))
  .unwrap();
```

---

With the old broken behaviour `output.vtt` will be:
```
WEBVTT
1
00:00:00.650 --> 00:00:01.200
foo
2
00:00:04.000 --> 00:00:06.000
bar
3
00:00:10.100 --> 00:00:18.999
baz
```

With the new fixed behaviour `output.vtt` will be:
```
WEBVTT

1
00:00:00.650 --> 00:00:01.200
foo

2
00:00:04.000 --> 00:00:06.000
bar

3
00:00:10.100 --> 00:00:18.999
baz
```
